### PR TITLE
Add without_ros support + thread_head example

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -16,6 +16,11 @@ set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_CXX_STANDARD_REQUIRED True)
 
 #
+# Options
+#
+OPTION(BUILD_WITH_ROS "Build with ROS" OFF)
+
+#
 # Dependencies
 #
 find_package(pybind11 CONFIG REQUIRED)
@@ -28,6 +33,10 @@ find_package(odri_control_interface REQUIRED)
 find_package(master_board_sdk REQUIRED)
 find_package(real_time_tools REQUIRED)
 find_package(yaml_utils REQUIRED)
+
+if (BUILD_WITH_ROS)
+  find_package(rclcpp REQUIRED)
+endif()
 
 # Find resources from robot_properties packages.
 find_package(PythonModules COMPONENTS robot_properties_nyu_finger)
@@ -66,6 +75,11 @@ if(${dynamic_graph_manager_FOUND})
   target_link_libraries(nyu_finger_hwp_cpp PRIVATE pybind11::module)
   target_link_libraries(nyu_finger_hwp_cpp PRIVATE nyu_finger)
   target_link_libraries(nyu_finger_hwp_cpp PRIVATE dynamic_graph_manager::dynamic_graph_manager)
+
+  # Define flag if building with ros.
+  if (BUILD_WITH_ROS)
+    target_compile_definitions(nyu_finger_hwp_cpp PUBLIC BUILD_WITH_ROS="true")
+  endif()
 
   install(TARGETS nyu_finger_hwp_cpp DESTINATION ${python_install_dir}/${PROJECT_NAME})
 endif(${dynamic_graph_manager_FOUND})

--- a/demos/nyu_finger_calibration_dgh.py
+++ b/demos/nyu_finger_calibration_dgh.py
@@ -10,7 +10,7 @@ yaml_file = os.path.join(
     NYUFingerConfig.dgm_yaml_dir, 'dgm_parameters_nyu_finger.yaml')
 
 # Create the dgm communication to the control process.
-head = dynamic_graph_manager_cpp_bindings.DGMHead(yaml_file_0)
+head = dynamic_graph_manager_cpp_bindings.DGMHead(yaml_file)
 
 P = np.zeros(3)
 D = 0.3 * np.ones(3)

--- a/demos/nyu_finger_thread_head.py
+++ b/demos/nyu_finger_thread_head.py
@@ -1,0 +1,74 @@
+# Author: Julian Viereck
+# Date: July 21, 2021
+#
+# Basic example demonstrating the use of thread_head for a single finger robot.
+#
+# To run this script launch a ipython terminal and run the script
+# 
+# source setup.bash
+# ipython
+# $ run nyu_finger_thread_head.py.
+
+import os.path
+import numpy as np
+import time
+import dynamic_graph_manager_cpp_bindings
+from dynamic_graph_head import ThreadHead, HoldPDController
+
+from robot_properties_nyu_finger.config import NYUFingerConfig
+
+# Specify the setup through a yaml file.
+yaml_file = os.path.join(
+    NYUFingerConfig.dgm_yaml_dir, 'dgm_parameters_nyu_finger.yaml')
+
+# Create the dgm communication to the control process.
+head = dynamic_graph_manager_cpp_bindings.DGMHead(yaml_file)
+
+P = 3.
+D = 0.05
+
+# The hold_pd controller holds the current position when its activated.
+# This controller is used as safety controller.
+hold_pd_controller = HoldPDController(head, P, D)
+
+# Example controller class.
+class PDController:
+    def __init__(self, head, Kp, Kd):
+        self.head = head
+
+        self.Kp = Kp
+        self.Kd = Kd
+
+        self.joint_positions = head.get_sensor('joint_positions')
+        self.joint_velocities = head.get_sensor('joint_velocities')
+
+    def warmup(self, thread_head):
+        self.initial_position = self.joint_positions.copy()
+
+    def run(self, thread_head):
+        tau = (
+            self.Kp * (self.initial_position - self.joint_positions) -
+            self.Kd * self.joint_velocities
+        )
+        self.head.set_control('ctrl_joint_torques', tau)
+
+# Instantiation of the PD controller:
+pd_ctrl = PDController(head, P, D)
+
+
+# The actual thread_head object which does the main control and safety handling.
+thread_head = ThreadHead(
+    0.001, # dt
+    hold_pd_controller, # safety controller
+    head, # thread heads
+    []    # utils
+)
+
+# Start the parallel processing.
+thread_head.start()
+
+# From ipython terminal, you might want to run one of the following commands:
+# 
+# $ thread_head.switch_controllers(pd_ctrl) # activates the D controller
+#
+# $ thread_head.start_logging(5) # Logs the current controller for 5 seconds.

--- a/include/nyu_finger/dynamic_graph_manager/dgm_nyu_finger.hpp
+++ b/include/nyu_finger/dynamic_graph_manager/dgm_nyu_finger.hpp
@@ -9,9 +9,12 @@
 #pragma once
 
 #include "nyu_finger/nyu_finger.hpp"
-#include "mim_msgs/srv/joint_calibration.hpp"
 #include "dynamic_graph_manager/hardware_process.hpp"
 #include "yaml_utils/yaml_cpp_fwd.hpp"
+
+#ifdef BUILD_WITH_ROS
+#include "mim_msgs/srv/joint_calibration.hpp"
+#endif
 
 namespace nyu_finger
 {
@@ -55,6 +58,7 @@ public:
     void set_motor_controls_from_map(
         const dynamic_graph_manager::VectorDGMap& map);
 
+#ifdef BUILD_WITH_ROS
     /**
      * @brief Ros callback for the callibration procedure. Warning the robot
      * will move to the next the joint index and back to "0" upon this call.
@@ -68,6 +72,7 @@ public:
     void calibrate_joint_position_callback(
         mim_msgs::srv::JointCalibration::Request::SharedPtr req,
         mim_msgs::srv::JointCalibration::Response::SharedPtr res);
+#endif
 
     /**
      * @brief Calibrate the robot joint position

--- a/src/dynamic_graph_manager/dgm_nyu_finger.cpp
+++ b/src/dynamic_graph_manager/dgm_nyu_finger.cpp
@@ -8,7 +8,10 @@
  */
 
 #include "nyu_finger/dynamic_graph_manager/dgm_nyu_finger.hpp"
+
+#ifdef BUILD_WITH_ROS
 #include "dynamic_graph_manager/ros.hpp"
+#endif
 
 namespace nyu_finger
 {
@@ -31,6 +34,7 @@ void DGMNYUFinger::initialize_drivers()
                         "index_to_zero_angle",
                         zero_to_index_angle_from_file_);
 
+#ifdef BUILD_WITH_ROS
     // Get the hardware communication ros node handle.
     dynamic_graph_manager::RosNodePtr ros_node_handle =
         dynamic_graph_manager::get_ros_node(com_ros_node_name_);
@@ -43,6 +47,7 @@ void DGMNYUFinger::initialize_drivers()
                       this,
                       std::placeholders::_1,
                       std::placeholders::_2)));
+#endif
 
     std::string network_id;
     YAML::ReadParameter(
@@ -173,6 +178,7 @@ void DGMNYUFinger::set_motor_controls_from_map(
     }
 }
 
+#ifdef BUILD_WITH_ROS
 void DGMNYUFinger::calibrate_joint_position_callback(
     mim_msgs::srv::JointCalibration::Request::SharedPtr,
     mim_msgs::srv::JointCalibration::Response::SharedPtr res)
@@ -186,6 +192,7 @@ void DGMNYUFinger::calibrate_joint_position_callback(
     // registered in the hardware process.
     res->sanity_check = true;
 }
+#endif
 
 void DGMNYUFinger::calibrate_joint_position(
     Eigen::Ref<nyu_finger::Vector3d> zero_to_index_angle)


### PR DESCRIPTION
This PR does a few things to avoid many small PRs:

* As it turns out the dgm package is not working properly on Ubuntu 20.04 at this point. This PR allows to build the NYU_Finger package without ros, which is disabled by default for now. 
* This PR fixes a typo in the demos/nyu_finger_calibration_dgh.py.
* Last but not least, add a demo for the finger robot using thread_head